### PR TITLE
WinRM updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This cookbook provides recipes for ensuring that a Windows 2012 R2 system is compliant with the CIS Benchmark for Windows 2012r2 L1 Memberserver InSpec Profile shipped with Chef Automate.
 
+NOTE: This version allows WinRM ! ! !
+
 ## Cookbooks
 
 This cookbook extends the excellent [Dev-Sec.io Windows Hardening Cookbook](https://github.com/dev-sec/chef-windows-hardening). Some patches should probably get upstreamed.
@@ -13,6 +15,7 @@ This cookbook extends the excellent [Dev-Sec.io Windows Hardening Cookbook](http
 ## License and Author
 
 * Author:: Matt Ray <matt@chef.io>
+* Lazy contributor:: Anthony Rees <anthony@chef.io>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/2_2_security_policy.rb
+++ b/attributes/2_2_security_policy.rb
@@ -12,3 +12,7 @@ default['security_policy']['rights']['SeDenyServiceLogonRight']           = '*S-
 default['security_policy']['rights']['SeDenyInteractiveLogonRight']       = '*S-1-5-32-546'
 # CIS 2.2.21 'Deny log on through Remote Desktop Services' to include 'Guests, Local account'
 default['security_policy']['rights']['SeDenyRemoteInteractiveLogonRight'] = '*S-1-5-32-546, *S-1-5-113'
+#
+# Added to allow WinRM access to scan
+default['security_policy']['rights']['SeRemoteInteractiveLogonRight']     = '*S-1-1-0, *S-1-5-32-544, *S-1-5-32-545, *S-1-5-32-551'
+default['security_policy']['rights']['SeNetworkLogonRight']               = '*S-1-1-0, *S-1-5-32-544, *S-1-5-32-545, *S-1-5-32-551'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'matt@chef.io'
 license 'Apache-2.0'
 description 'CIS Hardening cookbook for Windows 2012 R2'
 long_description 'Remediates issues identified by the cis-windows2012r2-level1-memberserver profile'
-version '0.1.0'
+version '0.1.1'
 source_url 'https://github.com/mattray/cis-win2012r2-l1-hardening-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/mattray/cis-win2012r2-l1-hardening-cookbook' if respond_to?(:issues_url)
 chef_version '>= 12.10' if respond_to?(:chef_version)


### PR DESCRIPTION
Added the Security Attributes to allow WinRM scanning in Chef Automate on AWS using the Win2012R2 Server Base AMI - ami-c55089bd